### PR TITLE
Improve currency handling

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -413,6 +413,9 @@ AUTO_LOGOUT = {
 # Assumed country based on timeseries data (used for map settings and user warning if a different country is selected)
 DEFAULT_COUNTRY = ("TH", "Thailand")
 
+# Currency in which all the default cost values are defined, also needed to define the exchange rate on currency switch
+DEFAULT_CURRENCY = "EUR"
+
 # Default url to privacy statement
 PRIVACY_URL = "https://offgridplanner.org/privacy"
 

--- a/offgridplanner/data/output_kpis.csv
+++ b/offgridplanner/data/output_kpis.csv
@@ -6,7 +6,7 @@ length_distribution_cable,Distribution Cable Length,m
 average_length_distribution_cable,Average Length Distribution Cable,m
 length_connection_cable,Connection Cable Length,m
 average_length_connection_cable,Average Length Connection Cable,m
-cost_grid,Grid annualized Cost,USD/a
+cost_grid,Grid annualized Cost,currency/a
 lcoe,Levelized Cost of Electricity (w/o SHS),cent/kWh
 lcoe_share_grid,Share of Grid-Related Costs in the LCOE,%
 lcoe_share_supply,Share of Generation-Related Costs in LCOE,%
@@ -18,16 +18,16 @@ time,Total simulation time,s
 co2_savings,Annual CO2 savings,t/a
 total_annual_consumption,Total annual Consumption,kWh/a
 average_annual_demand_per_consumer,Annual average Demand per Consumer,kWh
-upfront_invest_grid,Grid upfront Investment Cost,USD
-upfront_invest_diesel_genset,Diesel Generator upfront Investment Cost,USD
-upfront_invest_inverter,Inverter upfront Investment Cost,USD
-upfront_invest_rectifier,Rectifier upfront Investment Cost,USD
-upfront_invest_battery,Battery upfront Investment Cost,USD
-upfront_invest_pv,PV upfront Investment Cost,USD
-upfront_invest_h2_storage,H2 Storage upfront Investment Cost,USD
-upfront_invest_fuel_cell,Fuel cell upfront Investment Cost,USD
-upfront_invest_electrolyzer,Electrolyzer upfront Investment Cost,USD
-upfront_invest_total,Total upfront Investment Cost,USD
+upfront_invest_grid,Grid upfront Investment Cost,currency
+upfront_invest_diesel_genset,Diesel Generator upfront Investment Cost,currency
+upfront_invest_inverter,Inverter upfront Investment Cost,currency
+upfront_invest_rectifier,Rectifier upfront Investment Cost,currency
+upfront_invest_battery,Battery upfront Investment Cost,currency
+upfront_invest_pv,PV upfront Investment Cost,currency
+upfront_invest_h2_storage,H2 Storage upfront Investment Cost,currency
+upfront_invest_fuel_cell,Fuel cell upfront Investment Cost,currency
+upfront_invest_electrolyzer,Electrolyzer upfront Investment Cost,currency
+upfront_invest_total,Total upfront Investment Cost,currency
 battery_capacity,Capacity Battery,kWh
 pv_capacity,Capacity PV,kWp
 diesel_genset_capacity,Capacity Diesel Generator,kW
@@ -41,13 +41,13 @@ fuel_consumption,Annual Fuel Consumption,liter/a
 peak_demand,Peak Demand,kW
 base_load,Base Load,kW
 max_shortage,Max. Shortage per Time Step,%
-cost_fuel,Annual fuel cost,USD/a
-epc_pv,PV annualized Cost,USD/a
-epc_diesel_genset,Diesel Generator annualized Cost,USD/a
-epc_inverter,Inverter annualized Cost,USD/a
-epc_rectifier,Rectifier annualized Cost,USD/a
-epc_battery,Battery annualized Cost,USD/a
-epc_h2_storage,H2 Storage annualized Cost,USD/a
-epc_electrolyzer,Electrolyzer annualized Cost,USD/a
-epc_fuel_cell,Fuel cell annualized Cost,USD/a
-epc_total,Total annualized Cost,USD/a
+cost_fuel,Annual fuel cost,currency/a
+epc_pv,PV annualized Cost,currency/a
+epc_diesel_genset,Diesel Generator annualized Cost,currency/a
+epc_inverter,Inverter annualized Cost,currency/a
+epc_rectifier,Rectifier annualized Cost,currency/a
+epc_battery,Battery annualized Cost,currency/a
+epc_h2_storage,H2 Storage annualized Cost,currency/a
+epc_electrolyzer,Electrolyzer annualized Cost,currency/a
+epc_fuel_cell,Fuel cell annualized Cost,currency/a
+epc_total,Total annualized Cost,currency/a

--- a/offgridplanner/steps/forms.py
+++ b/offgridplanner/steps/forms.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.forms import ModelForm
 from django.utils.translation import gettext_lazy as _
 
+from config.settings.base import DEFAULT_CURRENCY
 from offgridplanner.projects.helpers import FORM_FIELD_METADATA
 from offgridplanner.projects.widgets import BatteryDesignWidget
 from offgridplanner.steps.models import CustomDemand
@@ -18,7 +19,7 @@ def set_field_metadata(field, meta):
     field.help_text = _(meta.get("help_text", ""))  # Set help text
     # TODO change hard coded unit to customizable in the future
     field.widget.attrs["unit"] = meta.get("unit", "").replace(
-        "currency", "USD"
+        "currency", DEFAULT_CURRENCY
     )  # Store unit as an attribute
 
 

--- a/offgridplanner/steps/views.py
+++ b/offgridplanner/steps/views.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
 
 from config.settings.base import DEFAULT_COUNTRY
+from config.settings.base import DEFAULT_CURRENCY
 from config.settings.base import PENDING
 from offgridplanner.optimization.helpers import get_country_bounds
 from offgridplanner.optimization.models import Results
@@ -358,6 +359,9 @@ def simulation_results(request, proj_id=None):
 
     for kpi in output_kpis:
         output_kpis[kpi]["value"] = df[kpi].round(1)
+        output_kpis[kpi]["unit"] = output_kpis[kpi]["unit"].replace(
+            "currency", DEFAULT_CURRENCY
+        )
 
     country_bounds = get_country_bounds(proj_id)
 


### PR DESCRIPTION
Define default currency once in global settings instead of hard-coded. No visible changes for the user yet, but more in preparation for different currencies and exchange rate settings later on.