### PR TITLE
Fix lcoh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 - Fix inconsistent decimal separator in forms (now dot across all fields) ([#70](https://github.com/rl-institut/offgridplanner-thailand/pull/70))
 - Fix link to about page ([#70](https://github.com/rl-institut/offgridplanner-thailand/pull/70))
+- Disable checking consumer country on import (was buggy for Thailand due to complex geometry) ([#75](https://github.com/rl-institut/offgridplanner-thailand/pull/75))
+- Fix non-zero LCOH values on zero H2-component scenarios ([#75](https://github.com/rl-institut/offgridplanner-thailand/pull/75))
 
 
 ## [v1.4.1-thai.6.0] – 2026-06-11

--- a/offgridplanner/optimization/helpers.py
+++ b/offgridplanner/optimization/helpers.py
@@ -230,11 +230,11 @@ def check_imported_consumer_data(df, proj_id):
         "is_connected": bool,
     }
     convert_column_types(df, column_types)
-    if not check_nodes_within_country(df, proj_id):
-        return None, (
-            "Some of the imported consumers are located outside the selected country. "
-            "Please verify the project country or check the coordinates in your CSV file."
-        )
+    # if not check_nodes_within_country(df, proj_id):
+    #     return None, (
+    #         "Some of the imported consumers are located outside the selected country. "
+    #         "Please verify the project country or check the coordinates in your CSV file."
+    #     )
 
     df = df[
         [

--- a/offgridplanner/optimization/processing.py
+++ b/offgridplanner/optimization/processing.py
@@ -618,7 +618,7 @@ class SupplyProcessor(OptimizationDataHandler):
         self.lcoe = 100 * self.total_revenue / self.total_demand
         self.lcoh = (
             100 * self.total_cost_hydrogen / sum(self.sequences["h2_storage_charge"])
-            if sum(self.sequences["h2_storage_charge"]) != 0
+            if round(sum(self.sequences["h2_storage_charge"])) != 0
             else 0
         )
         self.res = (

--- a/offgridplanner/templates/pages/simulation_results.html
+++ b/offgridplanner/templates/pages/simulation_results.html
@@ -80,6 +80,7 @@
                     <div class="item__unit">{{results.lcoe.unit}}</div>
                   </div>
                 </div>
+                {% if results.lcoh.value != 0 %}
                 <div class="item item--main">
                   <div class="item__name">{% translate "LCOH" %}</div>
                   <div class="item__result">
@@ -87,6 +88,7 @@
                     <div class="item__unit">{{results.lcoh.unit}}</div>
                   </div>
                 </div>
+                {% endif %}
                 <div class="item item--main">
                   <div class="item__name">{{results.upfront_invest_total.verbose}}</div>
                   <div class="item__result">


### PR DESCRIPTION
The function for LCOH was causing positive values even though components were not being built. This was due to very small numbers (rounding errors) in costs being divided by very small numbers in the flows (e.g. `1e-7 / 1e-8`), producing plausible LCOH results. Fixed by rounding before calculating LCOH and hiding field if zero. Closes #68.